### PR TITLE
fix for issues #55 and #58

### DIFF
--- a/src/main/java/org/codetracker/HistoryImpl.java
+++ b/src/main/java/org/codetracker/HistoryImpl.java
@@ -36,6 +36,7 @@ public class HistoryImpl<N extends CodeElement> implements History<N> {
               edgeValue.getChangeList(),
               edge.target().getVersion().getId(),
               edge.target().getVersion().getTime(),
+              edge.target().getVersion().getAuthoredTime(),
               edge.target().getVersion().getAuthorName());
       historyInfoList.add(historyInfoImpl);
     }
@@ -64,6 +65,7 @@ public class HistoryImpl<N extends CodeElement> implements History<N> {
     private final Set<Change> changeList = new HashSet<>();
     private final String commitId;
     private final long commitTime;
+    private final long authoredTime;
     private final String committerName;
 
     /**
@@ -72,6 +74,8 @@ public class HistoryImpl<N extends CodeElement> implements History<N> {
      * @param changeList Change List
      * @param commitId Commit ID
      * @param commitTime Commit Time
+     * @param authoredTime Commit Time
+     * @param committerName Committer Name
      */
     public HistoryInfoImpl(
         C elementBefore,
@@ -79,12 +83,14 @@ public class HistoryImpl<N extends CodeElement> implements History<N> {
         Set<Change> changeList,
         String commitId,
         long commitTime,
+        long authoredTime,
         String committerName) {
       this.elementBefore = elementBefore;
       this.elementAfter = elementAfter;
       this.changeList.addAll(changeList);
       this.commitId = commitId;
       this.commitTime = commitTime;
+      this.authoredTime = authoredTime;
       this.committerName = committerName;
     }
 
@@ -111,6 +117,11 @@ public class HistoryImpl<N extends CodeElement> implements History<N> {
     @Override
     public long getCommitTime() {
       return commitTime;
+    }
+
+    @Override
+    public long getAuthoredTime() {
+      return authoredTime;
     }
 
     @Override

--- a/src/main/java/org/codetracker/VersionImpl.java
+++ b/src/main/java/org/codetracker/VersionImpl.java
@@ -7,11 +7,13 @@ import java.util.Objects;
 public class VersionImpl implements Version {
   private final String id;
   private final long time;
+  private final long authoredTime;
   private final String authorName;
 
-  public VersionImpl(String id, long time, String authorName) {
+  public VersionImpl(String id, long time, long authoredTime, String authorName) {
     this.id = id;
     this.time = time;
+    this.authoredTime = authoredTime;
     this.authorName = authorName;
   }
 
@@ -23,6 +25,11 @@ public class VersionImpl implements Version {
   @Override
   public long getTime() {
     return this.time;
+  }
+
+  @Override
+  public long getAuthoredTime() {
+    return this.authoredTime;
   }
 
   @Override

--- a/src/main/java/org/codetracker/api/History.java
+++ b/src/main/java/org/codetracker/api/History.java
@@ -37,6 +37,8 @@ public interface History<C extends CodeElement> {
 
     long getCommitTime();
 
+    long getAuthoredTime();
+
     String getCommitterName();
   }
 }

--- a/src/main/java/org/codetracker/api/Version.java
+++ b/src/main/java/org/codetracker/api/Version.java
@@ -8,6 +8,9 @@ public interface Version {
   /** @return commit time */
   long getTime();
 
+  /** @return authored time  */
+  long getAuthoredTime();
+
   /** @return name of the committer */
   String getAuthorName();
 }

--- a/src/main/java/org/codetracker/util/GitHubRepository.java
+++ b/src/main/java/org/codetracker/util/GitHubRepository.java
@@ -30,7 +30,7 @@ public class GitHubRepository implements IRepository {
     if ("0".equals(commitId)) return commitTime;
     try {
       GHCommit currentCommit = repository.getCommit(commitId);
-      commitTime = currentCommit.getCommitDate().getTime();
+      commitTime = currentCommit.getAuthoredDate().getTime();
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/main/java/org/codetracker/util/GitHubRepository.java
+++ b/src/main/java/org/codetracker/util/GitHubRepository.java
@@ -30,6 +30,19 @@ public class GitHubRepository implements IRepository {
     if ("0".equals(commitId)) return commitTime;
     try {
       GHCommit currentCommit = repository.getCommit(commitId);
+      commitTime = currentCommit.getCommitDate().getTime();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return commitTime;
+  }
+
+  @Override
+  public long getAuthoredTime(String commitId) {
+    long commitTime = 0;
+    if ("0".equals(commitId)) return commitTime;
+    try {
+      GHCommit currentCommit = repository.getCommit(commitId);
       commitTime = currentCommit.getAuthoredDate().getTime();
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/org/codetracker/util/GitRepository.java
+++ b/src/main/java/org/codetracker/util/GitRepository.java
@@ -36,7 +36,8 @@ public class GitRepository implements IRepository {
   @Override
   public long getCommitTime(String commitId) {
     if ("0".equals(commitId)) return 0;
-    return getRevCommit(commitId).getCommitTime();
+    // convert time to Unix epoch
+    return getRevCommit(commitId).getAuthorIdent().getWhen().getTime() / 1000L;
   }
 
   @Override

--- a/src/main/java/org/codetracker/util/GitRepository.java
+++ b/src/main/java/org/codetracker/util/GitRepository.java
@@ -36,6 +36,12 @@ public class GitRepository implements IRepository {
   @Override
   public long getCommitTime(String commitId) {
     if ("0".equals(commitId)) return 0;
+    return getRevCommit(commitId).getCommitTime();
+  }
+
+  @Override
+  public long getAuthoredTime(String commitId) {
+    if ("0".equals(commitId)) return 0;
     // convert time to Unix epoch
     return getRevCommit(commitId).getAuthorIdent().getWhen().getTime() / 1000L;
   }

--- a/src/main/java/org/codetracker/util/IRepository.java
+++ b/src/main/java/org/codetracker/util/IRepository.java
@@ -21,6 +21,12 @@ public interface IRepository {
   long getCommitTime(String commitId);
 
   /**
+   * @param commitId the commit ID for which to find the authored time
+   * @return authored time
+   */
+  long getAuthoredTime(String commitId);
+
+  /**
    * @param commitId the commit ID that you wanted to find its author name
    * @return name of the committer
    */
@@ -31,6 +37,6 @@ public interface IRepository {
    * @return Version instance of the provided commit ID
    */
   default Version getVersion(String commitId) {
-    return new VersionImpl(commitId, getCommitTime(commitId), getCommitAuthorName(commitId));
+    return new VersionImpl(commitId, getCommitTime(commitId), getAuthoredTime(commitId), getCommitAuthorName(commitId));
   }
 }


### PR DESCRIPTION
By changing the `getCommitTime` implementation to use `getAuthoredTime` from `org.kohsuke.github` and `getAuthorIdent().getWhen()` from `JGit` instead of the commit time, we can get the exact time at which the commit was authored, which there by fixes issues caused by instances where multiple commits were committed in bulk, for example issue #55 and issue #58. There are also a lot of other instances that I have logged but not reported due to duplicity which will also be fixed. 