### PR TITLE
Fix broken history for #135

### DIFF
--- a/src/main/java/org/codetracker/AttributeTrackerImpl.java
+++ b/src/main/java/org/codetracker/AttributeTrackerImpl.java
@@ -218,7 +218,7 @@ public class AttributeTrackerImpl extends BaseTracker implements AttributeTracke
                     }
                 }
             }
-            return new HistoryImpl<>(attributeChangeHistory.findSubGraph(start), historyReport);
+            return new HistoryImpl<>(attributeChangeHistory.getCompleteGraph(), historyReport);
         }
     }
 

--- a/src/main/java/org/codetracker/BlockTrackerImpl.java
+++ b/src/main/java/org/codetracker/BlockTrackerImpl.java
@@ -294,7 +294,7 @@ public class BlockTrackerImpl extends BaseTracker implements BlockTracker {
                     }
                 }
             }
-            return new HistoryImpl<>(blockChangeHistory.findSubGraph(startBlock), historyReport);
+            return new HistoryImpl<>(blockChangeHistory.getCompleteGraph(), historyReport);
         }
     }
 

--- a/src/main/java/org/codetracker/ChangeHistory.java
+++ b/src/main/java/org/codetracker/ChangeHistory.java
@@ -126,6 +126,10 @@ public class ChangeHistory<T extends BaseCodeElement> {
         return GraphImpl.subGraph(changeHistoryGraph, start);
     }
 
+    public Graph<T, Edge> getCompleteGraph() {
+        return GraphImpl.of(changeHistoryGraph);
+    }
+
     public Set<T> predecessors(T codeElement) {
         return changeHistoryGraph.predecessors(codeElement);
     }

--- a/src/main/java/org/codetracker/ClassTrackerImpl.java
+++ b/src/main/java/org/codetracker/ClassTrackerImpl.java
@@ -162,7 +162,7 @@ public class ClassTrackerImpl extends BaseTracker implements ClassTracker {
                     }
                 }
             }
-            return new HistoryImpl<>(classChangeHistory.findSubGraph(start), historyReport);
+            return new HistoryImpl<>(classChangeHistory.getCompleteGraph(), historyReport);
         }
     }
 

--- a/src/main/java/org/codetracker/MethodTrackerImpl.java
+++ b/src/main/java/org/codetracker/MethodTrackerImpl.java
@@ -252,7 +252,7 @@ public class MethodTrackerImpl extends BaseTracker implements MethodTracker {
                     }
                 }
             }
-            return new HistoryImpl<>(methodChangeHistory.findSubGraph(start), historyReport);
+            return new HistoryImpl<>(methodChangeHistory.getCompleteGraph(), historyReport);
         }
     }
 

--- a/src/main/java/org/codetracker/VariableTrackerImpl.java
+++ b/src/main/java/org/codetracker/VariableTrackerImpl.java
@@ -329,7 +329,7 @@ public class VariableTrackerImpl extends BaseTracker implements VariableTracker 
                     }
                 }
             }
-            return new HistoryImpl<>(variableChangeHistory.findSubGraph(startVariable), historyReport);
+            return new HistoryImpl<>(variableChangeHistory.getCompleteGraph(), historyReport);
         }
     }
 


### PR DESCRIPTION
Closes #135 - Using the `findSubGraph` method doesn't always return the complete change history, which I also noticed while working on the GumTree branch.

The problem with `findSubGraph` is that the [`successors` & `predecessors`](https://github.com/jodavimehran/code-tracker/blob/f2220827723423cb18334a60cf726bbbf5593f6b/src/main/java/org/codetracker/GraphImpl.java#L46-L47) are not consistent between the two test cases described in #135, causing the history to be incomplete.

The fix I used here is the same approach I employed in the GumTree branch and may seem to be appropriate here as well.
