### PR TITLE
fix NPE on `blockBefore == null`

### DIFF
--- a/src/main/java/org/codetracker/BlockTrackerImpl.java
+++ b/src/main/java/org/codetracker/BlockTrackerImpl.java
@@ -576,7 +576,7 @@ public class BlockTrackerImpl extends BaseTracker implements BlockTracker {
                     break;
                 }
             }
-            if (changeType != null) {
+            if (changeType != null && blockBefore != null) {
                 if (equalOperator.test(blockAfter)) {
                     blockChangeHistory.addChange(blockBefore, blockAfter, ChangeFactory.forBlock(changeType).refactoring(refactoring));
                     leftBlockSet.add(blockBefore);


### PR DESCRIPTION
When `blockBefore` is null, the `leftBlockSet` is returned with `null` inside it, causing other methods that call this function to throw an `NPE`.  